### PR TITLE
Support access to service email in array

### DIFF
--- a/lib/accounts-meld-server.js
+++ b/lib/accounts-meld-server.js
@@ -601,33 +601,35 @@ updateOrCreateUserFromExternalService = function(serviceName, serviceData, optio
 			if (!user) {
 				// This service is being used for the first time!
 				// Extracts the email address associated with the current service
-				var serviceEmail = AccountsEmailsField.getEmailsFromService(
+				var serviceEmails = AccountsEmailsField.getEmailsFromService(
 					serviceName, serviceData
 				);
-				// In case it is a verified email...
-				if (serviceEmail.verified) {
-					// ...checks whether the email address used with the service is
-					// already associated with an existing account.
-					var otherUser = Meteor.users.findOne({
-						"registered_emails": {
-							$elemMatch: serviceEmail
-						}
-					});
-					if (otherUser) {
-						// Simply add the service to 'user', and that's it!
-						setAttr = {};
-						serviceIdKey = "services." + serviceName + ".id";
-						setAttr[serviceIdKey] = serviceData.id;
-						// This is just to fake updateOrCreateUserFromExternalService so to
-						// have it attach the new service to the existing user instead of
-						// creating a new one
-						Meteor.users.update({
-							_id: otherUser._id
-						}, {
-							$set: setAttr
+				serviceEmails.forEach(function(serviceEmail) {
+					// In case it is a verified email...
+					if (serviceEmail.verified) {
+						// ...checks whether the email address used with the service is
+						// already associated with an existing account.
+						var otherUser = Meteor.users.findOne({
+							"registered_emails": {
+								$elemMatch: serviceEmail
+							}
 						});
+						if (otherUser) {
+							// Simply add the service to 'user', and that's it!
+							setAttr = {};
+							serviceIdKey = "services." + serviceName + ".id";
+							setAttr[serviceIdKey] = serviceData.id;
+							// This is just to fake updateOrCreateUserFromExternalService so to
+							// have it attach the new service to the existing user instead of
+							// creating a new one
+							Meteor.users.update({
+								_id: otherUser._id
+							}, {
+								$set: setAttr
+							});
+						}
 					}
-				}
+				});
 			}
 		}
 	}


### PR DESCRIPTION
`AccountsEmailsField.getEmailsFromService` function is always returning an array after splendido:accounts-emails-field ver.1.0.3.
https://github.com/splendido/meteor-accounts-emails-field/commit/5ce51ad83e1c0cd592d51dc1a289f809b51319cc

Therefore serviceEmail variable is unconditionally an array.
`serviceEmail.verified` always returns `undefined`. I fixed it to `forEach`.