### PR TITLE
Support access to service email in array

### DIFF
--- a/lib/accounts-meld-server.js
+++ b/lib/accounts-meld-server.js
@@ -601,18 +601,23 @@ updateOrCreateUserFromExternalService = function(serviceName, serviceData, optio
 			if (!user) {
 				// This service is being used for the first time!
 				// Extracts the email address associated with the current service
-				var serviceEmail = AccountsEmailsField.getEmailsFromService(
+				var serviceEmails = AccountsEmailsField.getEmailsFromService(
 					serviceName, serviceData
-				);
+				).filter(function(serviceEmail) {
+					return serviceEmail.verified;
+				});
 				// In case it is a verified email...
-				if (serviceEmail.verified) {
+				if (serviceEmails.length) {
 					// ...checks whether the email address used with the service is
 					// already associated with an existing account.
-					var otherUser = Meteor.users.findOne({
-						"registered_emails": {
-							$elemMatch: serviceEmail
-						}
-					});
+					selector = {
+						$or: serviceEmails.map(function(serviceEmail) {
+							return {
+								"registered_emails": {$elemMatch: serviceEmail}
+							};
+						})
+					};
+					var otherUser = Meteor.users.findOne(selector);
 					if (otherUser) {
 						// Simply add the service to 'user', and that's it!
 						setAttr = {};

--- a/tests/accounts-meld_tests.js
+++ b/tests/accounts-meld_tests.js
@@ -733,9 +733,9 @@ if (Meteor.isClient) {
 			registerService(serviceName, userToLogInWith3rdParty),
 			start3rdPartyLogin(serviceName),
 			login3rdParty,
-			loggedInAs(userToLogInWith3rdParty),
+			loggedInAs(usersToMeld[0]),
 			assertUsersCount(otherUsers.length + 1),
-			assertUsersMissing(usersToMeld),
+			assertUsersMissing(userToLogInWith3rdParty),
 			logoutStep,
 			unregisterService(serviceName),
 			// Then, remakes same tests with askBeforeMeld = true
@@ -764,7 +764,7 @@ if (Meteor.isClient) {
 	);
 	test3rdPartyLoginWithUsersWithMeld(testSequence,
 		userFB1V,
-		[userPwd1V, userLO1V],
+		[userLO1V, userPwd1V],
 		[userFB1NV, userFB2NV, userFB2V, userLO1NV, userLO2NV, userLO2V]
 	);
 	testSequence.push(resetAll);


### PR DESCRIPTION
AccountsEmailsField.getEmailsFromService function is always returning an array after splendido:accounts-emails-field ver.1.0.3.
https://github.com/splendido/meteor-accounts-emails-field/commit/5ce51ad#diff-5a3494476ead98b2f4da442223634a5dR53
Therefore `serviceEmail` variable is unconditionally an array.
`serviceEmail.verified` always returns ‘undefined’. I changed it to `$or` selector.

Modify test case:
`insertUsers(usersToMeld)` runs first with `start3rdPartyLogin` running after. Original source users are `usersToMeld`.
However, checking `loggedInAs` to `userToLogInWith3rdParty` and `assertUsersMissing` to `usersToMeld` in `test3rdPartyLoginWithUsersWithMeld` is not right scenario.