### PR TITLE
Fix bug #21 via brettle:accounts-{add-service,accounts-multiple}

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ There are two different logic in place.
 
 The first one checks all login attempts looking for other accounts with at least one verified email address in common. If one such email is found the two accounts will be elected for melding (see below). In case of a meld action, the *surviving* user account will be the one just logged in.
 
-The second one permits the currently logged in user to add new services to its account: a call to `Meteor.loginWithSomething()` will be intercepted so to add the new service data to the current user object. In case another account using the same service associated with the same user id exists, the two accounts will be elected for melding (see below) and in case of a meld action is performed the *surviving* user account will be the currently logged in one. Although it is possible to add 3rd-party services to accounts created with classical sign-up flow (provided by `accounts-password`), at the moment it is **not** possible to do the contrary: a call to `Meteor.loginWithPassword` will log out the current user and login the one associated with the password service. After this, **only in case the email used with the password service is already verified**, the two account will be elected for melding (see below). In case of a meld action, the *surviving* user account will be the one originally associated with the password service.
-
+The second one permits the currently logged in user to add new services to its account: a call to `Meteor.loginWithSomething()` will be intercepted so to add the new service data to the current user object. In case another account using the same service associated with the same user id exists, the two accounts will be elected for melding (see below) and in case of a meld action is performed the *surviving* user account will be the currently logged in one.
 
 
 <a name="Melding"/>

--- a/lib/_globals.js
+++ b/lib/_globals.js
@@ -6,3 +6,5 @@ checkForMelds = undefined;
 MeldActions = undefined;
 
 updateOrCreateUserFromExternalService = undefined;
+
+validateSwitchCallback = undefined;

--- a/lib/accounts-meld-hooks.js
+++ b/lib/accounts-meld-hooks.js
@@ -1,6 +1,8 @@
 /* global
 	checkForMelds: false,
-	updateOrCreateUserFromExternalService: false
+	updateOrCreateUserFromExternalService: false,
+	AccountsMultiple: false,
+	validateSwitchCallback: false
 */
 'use strict';
 
@@ -24,4 +26,8 @@ Accounts.onLogin(function(attempt) {
 
 	// Checks for possible meld actions to be created
 	checkForMelds(user);
+});
+
+AccountsMultiple.register({
+	validateSwitch: validateSwitchCallback
 });

--- a/lib/accounts-meld-server.js
+++ b/lib/accounts-meld-server.js
@@ -3,7 +3,8 @@
     AccountsMeld: true,
     checkForMelds: true,
 		MeldActions: true,
-    updateOrCreateUserFromExternalService: true
+    updateOrCreateUserFromExternalService: true,
+		validateSwitchCallback: true
 */
 'use strict';
 
@@ -638,4 +639,51 @@ updateOrCreateUserFromExternalService = function(serviceName, serviceData, optio
 	}
 	// Let the user in!
 	return origUpdateOrCreateUserFromExternalService.apply(this, arguments);
+};
+
+validateSwitchCallback = function (currentUser, attempt) {
+	if (!attempt.allowed) {
+		return false;
+	}
+	if (attempt.type !== "password") {
+		return true;
+	}
+	var user = attempt.user;
+	if (user && user.services && user.services.resume)
+		// This service was already registered for "attempt.user"
+		if (AccountsMeld.getConfig('askBeforeMeld')) {
+			// Checks if there is already a document about this meld action
+			var meldAction = MeldActions.findOne({
+				src_user_id: user._id,
+				dst_user_id: currentUser._id
+			});
+			if (meldAction) {
+				// If the last time the answer was "Not now", ask again...
+				if (meldAction.meld === "not_now") {
+					MeldActions.update(meldAction._id, {
+						$set: {
+							meld: "ask"
+						}
+					});
+				}
+			} else {
+				// Creates a new meld action
+				AccountsMeld.createMeldAction(user, currentUser);
+			}
+
+			// Cancels the login
+			throw new Meteor.Error(
+				Accounts.LoginCancelledError.numericError,
+				"Another account registered with the same service was found!"
+			);
+		} else {
+			// Directly melds the two accounts
+			AccountsMeld.meldAccounts(user, currentUser);
+			// Cancels the login
+			throw new Meteor.Error(
+				Accounts.LoginCancelledError.numericError,
+				"Another account registered with the same service was found, " +
+				"and melded with the current one!"
+			);
+		}
 };

--- a/package.js
+++ b/package.js
@@ -16,6 +16,8 @@ Package.onUse(function(api) {
 		'check',
 		'underscore',
 		'splendido:accounts-emails-field@1.2.0',
+		'brettle:accounts-multiple@0.3.0',
+		'brettle:accounts-add-service@0.3.0',
 	], ['server']);
 
 	api.addFiles([

--- a/tests/accounts-meld_tests.js
+++ b/tests/accounts-meld_tests.js
@@ -167,7 +167,7 @@ if (Meteor.isClient) {
 	// User registered with service password with non-verified email
 	var userPwd1NV = {
 		username: Random.id(),
-		email: "pippo1@example",
+		email: "pippo1@example.com",
 		emails: [{
 			address: "pippo1@example.com",
 			verified: false
@@ -188,7 +188,7 @@ if (Meteor.isClient) {
 	// User registered with service password with Verified email
 	var userPwd1V = {
 		username: Random.id(),
-		email: "pippo1@example",
+		email: "pippo1@example.com",
 		emails: [{
 			address: "pippo1@example.com",
 			verified: true
@@ -209,7 +209,7 @@ if (Meteor.isClient) {
 	// User registered with service password with non-Verified email
 	var userPwd2NV = {
 		username: Random.id(),
-		email: "pippo2@example",
+		email: "pippo2@example.com",
 		emails: [{
 			address: "pippo2@example.com",
 			verified: false
@@ -230,7 +230,7 @@ if (Meteor.isClient) {
 	// User registered with service password with Verified email
 	var userPwd2V = {
 		username: Random.id(),
-		email: "pippo2@example",
+		email: "pippo2@example.com",
 		emails: [{
 			address: "pippo2@example.com",
 			verified: true
@@ -526,11 +526,44 @@ if (Meteor.isClient) {
 	var justWait = function(test, expect) {
 		return expect(function() {});
 	};
+	var registerWithPassword = function(user) {
+		return function(test, expect) {
+			Accounts.createUser({
+				username: user.username,
+				email: user.email,
+				password: user.profile.id,
+				profile: user.profile
+			}, PasswordAddedError(test, expect));
+		};
+	};
 	var pwdLogin = function(user) {
 		return function(test, expect) {
 			Meteor.loginWithPassword({
-				username: user.username
+				// use email instead of username because accounts-add-service does not
+				// replace username when adding a service (including password) to an
+				// account that already has a username.
+				email: user.email
 			}, user.profile.id, noError(test, expect));
+		};
+	};
+	var pwdLoginAdded = function(user) {
+		return function(test, expect) {
+			Meteor.loginWithPassword({
+				// use email instead of username because accounts-add-service does not
+				// replace username when adding a service (including password) to an
+				// account that already has a username.
+				email: user.email
+			}, user.profile.id, AlreadyExistingServiceAddedError(test, expect));
+		};
+	};
+	var pwdLoginMelded = function(user) {
+		return function(test, expect) {
+			Meteor.loginWithPassword({
+				// use email instead of username because accounts-add-service does not
+				// replace username when adding a service (including password) to an
+				// account that already has a username.
+				email: user.email
+			}, user.profile.id, AlreadyExistingServiceMeldedError(test, expect));
 		};
 	};
 	var registerService = function(serviceName, user) {
@@ -546,6 +579,14 @@ if (Meteor.isClient) {
 			test.equal(
 				error.reason,
 				"Service correctly added to the current user, no need to proceed!"
+			);
+		});
+	};
+	var PasswordAddedError = function(test, expect) {
+		return expect(function(error) {
+			test.equal(
+				error.reason,
+				'New login not needed. Service will be added to logged in user.'
 			);
 		});
 	};
@@ -988,6 +1029,112 @@ if (Meteor.isClient) {
 	testSequence.push(resetAll);
 	testAsyncMulti(
 		"accounts-meld - already logged in with service and add service and meld",
+		testSequence
+	);
+
+	var testServiceLoginPlusAddPasswordNoMeld = function(testSequence, users, userWithPasswordToAdd) {
+		// The first user in list will be used to perform the login test
+		var serviceName = _.keys(users[0].services)[0];
+		testSequence.push.apply(testSequence, [
+			// At first, makes tests with askBeforeMeld = false
+			resetAll,
+			registerService(serviceName, users[0]),
+			insertUsers(users),
+			assertUsersCount(users.length),
+			askBeforeMeld(false),
+			start3rdPartyLogin(serviceName),
+			login3rdParty,
+			loggedInAs(users[0]),
+			unregisterService(serviceName),
+			registerWithPassword(userWithPasswordToAdd),
+			pwdLogin(userWithPasswordToAdd),
+			loggedInAs(users[0]),
+			assertUsersCount(users.length),
+			logoutStep,
+			// Then, remakes same tests with askBeforeMeld = true
+			resetAll,
+			registerService(serviceName, users[0]),
+			insertUsers(users),
+			assertUsersCount(users.length),
+			askBeforeMeld(true),
+			start3rdPartyLogin(serviceName),
+			login3rdParty,
+			loggedInAs(users[0]),
+			unregisterService(serviceName),
+			registerWithPassword(userWithPasswordToAdd),
+			pwdLogin(userWithPasswordToAdd),
+			loggedInAs(users[0]),
+			assertUsersCount(users.length),
+			assertMeldActionsCount(0),
+			logoutStep,
+		]);
+	};
+	// No meld action is expected to be created here...
+	testSequence = [];
+	testServiceLoginPlusAddPasswordNoMeld(
+		testSequence,
+		[userFB1V, userFB2NV, userFB2V, userLO2NV, userLO2V, userPwd2NV],
+		userPwd1NV
+	);
+	testSequence.push(resetAll);
+	testAsyncMulti(
+		"accounts-meld - already logged in with service and add password (no meld)",
+		testSequence
+	);
+
+
+
+	var testServiceLoginPlusAddPasswordAndMeld = function(testSequence, users, userWithPasswordToAdd) {
+		// The first user in list will be used to perform the login test
+		var serviceName = _.keys(users[0].services)[0];
+		testSequence.push.apply(testSequence, [
+			// At first, makes tests with askBeforeMeld = false
+			resetAll,
+			registerService(serviceName, users[0]),
+			insertUsers(users),
+			assertUsersCount(users.length),
+			pwdLogin(userWithPasswordToAdd), // Adds resume service that marks account as pre-existing
+			logoutStep,
+			askBeforeMeld(false),
+			start3rdPartyLogin(serviceName),
+			login3rdParty,
+			loggedInAs(users[0]),
+			unregisterService(serviceName),
+			pwdLoginMelded(userWithPasswordToAdd),
+			loggedInAs(users[0]),
+			assertUsersCount(users.length - 1),
+			assertUsersMissing(userWithPasswordToAdd),
+			logoutStep,
+			// Then, remakes same tests with askBeforeMeld = true
+			resetAll,
+			registerService(serviceName, users[0]),
+			insertUsers(users),
+			assertUsersCount(users.length),
+			pwdLogin(userWithPasswordToAdd), // Adds resume service that marks account as pre-existing
+			logoutStep,
+			askBeforeMeld(true),
+			start3rdPartyLogin(serviceName),
+			login3rdParty,
+			loggedInAs(users[0]),
+			unregisterService(serviceName),
+			pwdLoginAdded(userWithPasswordToAdd),
+			loggedInAs(users[0]),
+			assertUsersCount(users.length),
+			assertMeldActionsCount(1),
+			assertMeldActionsCorrect(users[0], [userWithPasswordToAdd]),
+			logoutStep,
+		]);
+	};
+	// No meld action is expected to be created here...
+	testSequence = [];
+	testServiceLoginPlusAddPasswordAndMeld(
+		testSequence,
+		[userFB1V, userFB2NV, userFB2V, userLO2NV, userLO2V, userPwd1NV, userPwd2NV],
+		userPwd1NV
+	);
+	testSequence.push(resetAll);
+	testAsyncMulti(
+		"accounts-meld - already logged in with service and add password and meld",
 		testSequence
 	);
 }


### PR DESCRIPTION
Fix the "add new password account" case by just doing
`api.use('brettle:accounts-add-service')`.

Fix the "meld existing password account" case by copying logic from
`updateOrCreateUserFromExternalService()` into a `validateSwitch`
callback registered with `brettle:accounts-multiple`.

Add tests for both cases.
